### PR TITLE
Add gulp-sourcemaps support

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var requirejs = require('requirejs');
 var chalk = require('chalk');
+var applySourceMap = require('vinyl-sourcemaps-apply');
 
 var PLUGIN_NAME = 'gulp-requirejs-optimize';
 
@@ -51,7 +52,8 @@ module.exports = function(options) {
 		optimizeOptions = defaults({}, optimizeOptions, {
 			logLevel: 2,
 			baseUrl: file.base,
-			out: file.relative
+			out: file.relative,
+			generateSourceMaps: !!file.sourceMap
 		});
 
 		if (!optimizeOptions.include && !optimizeOptions.name) {
@@ -64,11 +66,17 @@ module.exports = function(options) {
 		}
 
 		var out = optimizeOptions.out;
-		optimizeOptions.out = function(text) {
-			cb(null, new gutil.File({
+		optimizeOptions.out = function(text, sourceMapText) {
+			var file = new gutil.File({
 				path: out,
 				contents: new Buffer(text)
-			}));
+			});
+
+			if (sourceMapText) {
+				applySourceMap(file, sourceMapText);
+			}
+
+			cb(null, file);
 		};
 
 		gutil.log('Optimizing ' + chalk.magenta(file.relative));

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "gulp-util": "^3.0.4",
+    "lodash.defaults": "^3.1.0",
     "requirejs": "^2.1.17",
     "through2": "^0.6.3",
-    "lodash.defaults": "^3.1.0"
+    "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
     "gulp": "^3.8.11",


### PR DESCRIPTION
Allows you to use the optimizer's generated sourcemaps:

``` javascript
var gulp = require('gulp');
var requirejsOptimize = require('gulp-requirejs-optimize');
var sourcemaps = require('gulp-sourcemaps');

gulp.task('scripts', function () {
    return gulp.src('src/main.js')
        .pipe(sourcemaps.init())
        .pipe(requirejsOptimize())
        .pipe(sourcemaps.write())
        .pipe(gulp.dest('dist'));
});
```
