### PR TITLE
Use the full path to module files for 'optimize' messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ module.exports = function(options) {
 			cb(null, file);
 		};
 
-		gutil.log('Optimizing ' + chalk.magenta(file.relative));
+		gutil.log('Optimizing ' + chalk.magenta(file.path));
 		requirejs.optimize(optimizeOptions, null, function(err) {
 			error = err;
 			cb();


### PR DESCRIPTION
This change is useful when debugging build errors which do not contain
clear information where the errors occurred.
